### PR TITLE
Keep selected text between surrounding chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Tested under Chrome+Tampermonkey, Vivaldi+Violent Monkey (thanks @jesus2099), Fi
 
 ** Under opera, the Ctrl+M shortcut of the script will overwrite the Opera default Ctrl+M for tab navigation. Just click out the inputbox to use Opera Ctrl+M tab navigation.
 
+  0.10.4 : Add Multiplication Sign, Wave Dash and Corner Brackets
+
   0.10.1 : Add Figure Dash
 
   0.10.0 : Fix issue #2 (https://github.com/Smeulf/userscripts/issues/2) (Thanks jesus2099)

--- a/mb.unicodechars.user.js
+++ b/mb.unicodechars.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         mb.unicodechars
 // @namespace    https://github.com/Smeulf/userscripts
-// @version      0.10.4
+// @version      0.10.5
 // @description  Ctrl+M on MusicBrainz input text or textarea controls shows context menu for unicode characters. Just click on the menu line to send the character or close with Escape key.
 // @author       Smeulf
 // @match        *://*.musicbrainz.org/*
@@ -198,9 +198,8 @@ function onMenuOptionClic(event)
     {
         id = event.target.parentElement.id;
     }
-
     unsafeWindow.lastInputClicked.value = unsafeWindow.lastInputClicked.value.substr(0, unsafeWindow.selectionStart)
-        + id
+        + id.replace(/%s/g, unsafeWindow.lastInputClicked.value.substring(unsafeWindow.selectionStart, unsafeWindow.selectionEnd))
         + unsafeWindow.lastInputClicked.value.substr(unsafeWindow.selectionEnd);
     var menu = document.getElementById("mbunicodecharsMenu");
     var cn = menu.childNodes;
@@ -209,7 +208,11 @@ function onMenuOptionClic(event)
 
     unsafeWindow.menuOpened = false;
     unsafeWindow.lastInputClicked.focus();
-    unsafeWindow.lastInputClicked.setSelectionRange(unsafeWindow.selectionStart+1, unsafeWindow.selectionStart+1);
+    if (id.length > 1 && unsafeWindow.selectionStart != unsafeWindow.selectionEnd) {
+		unsafeWindow.lastInputClicked.setSelectionRange(unsafeWindow.selectionStart + 1, unsafeWindow.selectionEnd + 1);
+    } else {
+		unsafeWindow.lastInputClicked.setSelectionRange(unsafeWindow.selectionStart + 1, unsafeWindow.selectionStart + 1);
+    }
     var ev = document.createEvent('HTMLEvents');
     ev.initEvent('change', true, true);
     unsafeWindow.lastInputClicked.dispatchEvent(ev);
@@ -243,7 +246,7 @@ function buildMenu()
     {
         if (menuItems[i].enabled)
         {
-            str.push('<div id="'+menuItems[i].code+'" class="mbunicodecharsOptionRow"><div class="mbunicodecharsOptionLeftColumn">'+menuItems[i].code+
+            str.push('<div id="'+menuItems[i].code+'" class="mbunicodecharsOptionRow"><div class="mbunicodecharsOptionLeftColumn">'+menuItems[i].code.replace(/%s/g, "")+
                      '</div><div class="mbunicodecharsOptionRightColumn">'+menuItems[i].name+'</div></div>');
         }
         if (menuItems[i].default)
@@ -271,7 +274,7 @@ function updateLanguagePack(source)
     if (source === undefined)
     {
         //Update from local worldwide punctuation
-        newLanguagePack = {"code":"XW", "name": "Worldwide punctuation", "version": "0.10.4", "menuItems":[]};
+        newLanguagePack = {"code":"XW", "name": "Worldwide punctuation", "version": "0.10.5", "menuItems":[]};
 
         if (languagePacks !== null)
         {
@@ -283,17 +286,17 @@ function updateLanguagePack(source)
             }
         }
 
-        console.log("mb.unicodechars: update requiried to version "+newLanguagePack.version);
+        console.log("mb.unicodechars: update required to version "+newLanguagePack.version);
 
         newLanguagePack.menuItems = [
             {"code": "\u2018", "name": "Left Single Quote", "offset":1, "enabled":true, "default":false},
             {"code": "\u2019", "name": "Apostrophe, Right Single Quote", "offset":1, "enabled":true, "default":true},
-            {"code": "\u2018\u2019", "name": "Left+Right Single Quotes", "offset":1, "enabled":true, "default":false},
+            {"code": "\u2018%s\u2019", "name": "Left+Right Single Quotes", "offset":1, "enabled":true, "default":false},
             {"code": "\u201C", "name": "Left Double Quotes", "offset":1, "enabled":true, "default":false},
             {"code": "\u201D", "name": "Right Double Quotes", "offset":1, "enabled":true, "default":false},
-            {"code": "\u201C\u201D", "name": "Left+Right Double Quotes", "offset":1, "enabled":true, "default":false},
-            {"code": "\u300C\u300D", "name": "Left+Right Corner Brackets", "offset":1, "enabled":true, "default":false},
-            {"code": "\u300E\u300F", "name": "Left+Right White Corner Brackets", "offset":1, "enabled":true, "default":false},
+            {"code": "\u201C%s\u201D", "name": "Left+Right Double Quotes", "offset":1, "enabled":true, "default":false},
+            {"code": "\u300C%s\u300D", "name": "Left+Right Corner Brackets", "offset":1, "enabled":true, "default":false},
+            {"code": "\u300E%s\u300F", "name": "Left+Right White Corner Brackets", "offset":1, "enabled":true, "default":false},
             {"code": "\u2026", "name": "Horizontal Ellipsis", "offset":1, "enabled":true, "default":false},
             {"code": "\u2010", "name": "Hyphen", "offset":1, "enabled":true, "default":false},
             {"code": "\u2013", "name": "En Dash", "offset":1, "enabled":true, "default":false},

--- a/mb.unicodechars.user.js
+++ b/mb.unicodechars.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         mb.unicodechars
 // @namespace    https://github.com/Smeulf/userscripts
-// @version      0.10.1
+// @version      0.10.4
 // @description  Ctrl+M on MusicBrainz input text or textarea controls shows context menu for unicode characters. Just click on the menu line to send the character or close with Escape key.
 // @author       Smeulf
 // @match        *://*.musicbrainz.org/*
@@ -271,7 +271,7 @@ function updateLanguagePack(source)
     if (source === undefined)
     {
         //Update from local worldwide punctuation
-        newLanguagePack = {"code":"XW", "name": "Worldwide punctuation", "version": "0.9.0", "menuItems":[]};
+        newLanguagePack = {"code":"XW", "name": "Worldwide punctuation", "version": "0.10.4", "menuItems":[]};
 
         if (languagePacks !== null)
         {
@@ -292,14 +292,18 @@ function updateLanguagePack(source)
             {"code": "\u201C", "name": "Left Double Quotes", "offset":1, "enabled":true, "default":false},
             {"code": "\u201D", "name": "Right Double Quotes", "offset":1, "enabled":true, "default":false},
             {"code": "\u201C\u201D", "name": "Left+Right Double Quotes", "offset":1, "enabled":true, "default":false},
+            {"code": "\u300C\u300D", "name": "Left+Right Corner Brackets", "offset":1, "enabled":true, "default":false},
+            {"code": "\u300E\u300F", "name": "Left+Right White Corner Brackets", "offset":1, "enabled":true, "default":false},
             {"code": "\u2026", "name": "Horizontal Ellipsis", "offset":1, "enabled":true, "default":false},
             {"code": "\u2010", "name": "Hyphen", "offset":1, "enabled":true, "default":false},
-            {"code": "\u2212", "name": "Minus", "offset":1, "enabled":true, "default":false},
             {"code": "\u2013", "name": "En Dash", "offset":1, "enabled":true, "default":false},
             {"code": "\u2014", "name": "Em Dash", "offset":1, "enabled":true, "default":false},
-			{"code": "\u2012", "name": "Figure Dash", "offset":1, "enabled":true, "default":false},
+            {"code": "\u2012", "name": "Figure Dash", "offset":1, "enabled":true, "default":false},
+            {"code": "\u301C", "name": "Wave Dash", "offset":1, "enabled":true, "default":false},
             {"code": "\u2032", "name": "Prime", "offset":1, "enabled":true, "default":false},
-            {"code": "\u2033", "name": "Double Prime", "offset":1, "enabled":true, "default":false}
+            {"code": "\u2033", "name": "Double Prime", "offset":1, "enabled":true, "default":false},
+            {"code": "\u2212", "name": "Minus Sign", "offset":1, "enabled":true, "default":false},
+            {"code": "\u00D7", "name": "Multiplication Sign", "offset":1, "enabled":true, "default":false}
         ];
     }
     else


### PR DESCRIPTION
If you select **these three words**, then press Ctrl+M and choose Left+Right double quotes, it will add the quotes around the selected text and make it turn into: **“these three words”**

It works for:

- Left+Right Single Quotes
- Left+Right Double Quotes
- Left+Right Corner Brackets
- Left+Right White Corner Brackets